### PR TITLE
Improve CLI menu

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,0 +1,7 @@
+import chalk from 'chalk'
+import { displayMainMenu } from './menus/mainMenu.js'
+
+console.clear()
+console.log(chalk.cyanBright('🚀  Bem-vindo ao ') + chalk.magentaBright.bold('Voyin'))
+
+await displayMainMenu()

--- a/cli/menus/mainMenu.ts
+++ b/cli/menus/mainMenu.ts
@@ -1,0 +1,33 @@
+import inquirer from 'inquirer'
+import chalk from 'chalk'
+
+export async function displayMainMenu(): Promise<void> {
+  const choices = [
+    { name: '📁 Gerenciar Arquivos', value: 'file' },
+    { name: '📂 Gerenciar Pastas', value: 'folder' },
+    { name: '🧠 Organizar Arquivos', value: 'organizer' },
+    { name: '📊 Relatórios', value: 'report' },
+    { name: '♻️ Detectar Duplicados', value: 'duplicator' },
+    { name: '🔁 Conversores', value: 'converter' },
+    { name: '⚙️ Extras', value: 'extras' },
+    { name: chalk.red('❌ Sair'), value: 'exit' }
+  ]
+
+  const { option } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'option',
+      message: chalk.bold('Selecione uma opção:'),
+      choices
+    }
+  ])
+
+  switch (option) {
+    case 'exit':
+      console.log(chalk.green('Até logo!'))
+      return
+    default:
+      console.log(chalk.yellow('Funcionalidade ainda não implementada.'))
+      return displayMainMenu()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
+    "cli": "tsx cli/index.ts",
     "start": "node dist/index.js",
     "build": "tsc",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary
- add CLI entry point with chalk
- add main menu with icons and color
- enable CLI run script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68574008c2388330b9e64df9e7e3f6a1