### PR TITLE
Implement dynamic CLI menus

### DIFF
--- a/cli/actions/handleConverter.ts
+++ b/cli/actions/handleConverter.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleConverter(): Promise<void> {
+  console.log(chalk.yellow('Conversor ainda não implementado.'))
+}

--- a/cli/actions/handleDuplicator.ts
+++ b/cli/actions/handleDuplicator.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleDuplicator(): Promise<void> {
+  console.log(chalk.yellow('Detecção de duplicados ainda não implementada.'))
+}

--- a/cli/actions/handleExtras.ts
+++ b/cli/actions/handleExtras.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleExtras(): Promise<void> {
+  console.log(chalk.yellow('Funcionalidades extras ainda não implementadas.'))
+}

--- a/cli/actions/handleFile.ts
+++ b/cli/actions/handleFile.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleFile(): Promise<void> {
+  console.log(chalk.yellow('Funcionalidade de arquivos ainda não implementada.'))
+}

--- a/cli/actions/handleFolder.ts
+++ b/cli/actions/handleFolder.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleFolder(): Promise<void> {
+  console.log(chalk.yellow('Funcionalidade de pastas ainda não implementada.'))
+}

--- a/cli/actions/handleOrganizer.ts
+++ b/cli/actions/handleOrganizer.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleOrganizer(): Promise<void> {
+  console.log(chalk.yellow('Organizador ainda não implementado.'))
+}

--- a/cli/actions/handleReport.ts
+++ b/cli/actions/handleReport.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export async function handleReport(): Promise<void> {
+  console.log(chalk.yellow('Geração de relatórios ainda não implementada.'))
+}

--- a/cli/actions/index.ts
+++ b/cli/actions/index.ts
@@ -1,0 +1,7 @@
+export * from './handleFile.js'
+export * from './handleFolder.js'
+export * from './handleOrganizer.js'
+export * from './handleReport.js'
+export * from './handleDuplicator.js'
+export * from './handleConverter.js'
+export * from './handleExtras.js'

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
-import { displayMainMenu } from './menus/mainMenu.js'
+import { navigateMenu } from './menus/navigator.js'
 
 console.clear()
 console.log(chalk.cyanBright('🚀  Bem-vindo ao ') + chalk.magentaBright.bold('Voyin'))
 
-await displayMainMenu()
+await navigateMenu('main')

--- a/cli/menus/menuData.ts
+++ b/cli/menus/menuData.ts
@@ -1,0 +1,98 @@
+// Menu definitions for the CLI
+import chalk from 'chalk'
+import {
+  handleFile,
+  handleFolder,
+  handleOrganizer,
+  handleReport,
+  handleDuplicator,
+  handleConverter,
+  handleExtras
+} from '../actions/index.js'
+
+export interface MenuOption {
+  name: string
+  value: string
+  next?: string
+  action?: () => Promise<void>
+}
+
+export interface MenuDefinition {
+  label: string
+  message: string
+  options: MenuOption[]
+}
+
+export const menus: Record<string, MenuDefinition> = {
+  main: {
+    label: 'Principal',
+    message: 'Selecione uma opção:',
+    options: [
+      { name: '📁 Gerenciar Arquivos', value: 'file', next: 'file' },
+      { name: '📂 Gerenciar Pastas', value: 'folder', next: 'folder' },
+      { name: '🧠 Organizar Arquivos', value: 'organizer', next: 'organizer' },
+      { name: '📊 Relatórios', value: 'report', next: 'report' },
+      { name: '♻️ Detectar Duplicados', value: 'duplicator', next: 'duplicator' },
+      { name: '🔁 Conversores', value: 'converter', next: 'converter' },
+      { name: '⚙️ Extras', value: 'extras', next: 'extras' },
+      { name: chalk.red('❌ Sair'), value: 'exit', next: 'exit' }
+    ]
+  },
+  file: {
+    label: 'Arquivos',
+    message: 'Gerenciar arquivos:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleFile },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  },
+  folder: {
+    label: 'Pastas',
+    message: 'Gerenciar pastas:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleFolder },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  },
+  organizer: {
+    label: 'Organizador',
+    message: 'Organizar arquivos:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleOrganizer },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  },
+  report: {
+    label: 'Relatórios',
+    message: 'Gerar relatórios:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleReport },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  },
+  duplicator: {
+    label: 'Duplicados',
+    message: 'Detectar duplicados:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleDuplicator },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  },
+  converter: {
+    label: 'Conversores',
+    message: 'Converter arquivos:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleConverter },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  },
+  extras: {
+    label: 'Extras',
+    message: 'Opções extras:',
+    options: [
+      { name: 'Em breve...', value: 'placeholder', action: handleExtras },
+      { name: '🔙 Voltar', value: 'back', next: '..' }
+    ]
+  }
+}
+;

--- a/cli/menus/navigator.ts
+++ b/cli/menus/navigator.ts
@@ -1,0 +1,55 @@
+import inquirer from 'inquirer'
+import chalk from 'chalk'
+import { menus } from './menuData.js'
+
+export async function navigateMenu(
+  menuKey: string = 'main',
+  history: string[] = []
+): Promise<void> {
+  const menu = menus[menuKey]
+  if (!menu) {
+    console.log(chalk.red('Menu não encontrado.'))
+    return
+  }
+
+  console.clear()
+  const breadcrumb = ['Voyin', ...history.map(k => menus[k].label), menu.label].join(
+    chalk.gray(' » ')
+  )
+  console.log(chalk.magentaBright.bold(breadcrumb))
+
+  const { option } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'option',
+      message: chalk.bold(menu.message),
+      choices: menu.options.map(o => ({ name: o.name, value: o.value }))
+    }
+  ])
+
+  const choice = menu.options.find(c => c.value === option)
+  if (!choice) return
+
+  if (choice.action) {
+    await choice.action()
+  }
+
+  if (choice.next === 'exit') {
+    console.log(chalk.green('Até logo!'))
+    return
+  }
+
+  if (choice.next === '..') {
+    const prev = history.pop() || 'main'
+    await navigateMenu(prev, history)
+    return
+  }
+
+  if (choice.next) {
+    history.push(menuKey)
+    await navigateMenu(choice.next, history)
+    return
+  }
+
+  await navigateMenu(menuKey, history)
+}


### PR DESCRIPTION
## Summary
- add placeholders for CLI actions
- implement generic menu navigation logic
- add menu definitions for every CLI path
- bootstrap CLI to use the dynamic navigator

## Testing
- `npm run build` *(fails: Cannot find module declarations)*
- `npm run cli` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_685741ae30a883309dbc6288e3f95885