### PR TITLE
Implement complete CLI menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ voyin/
 ├── tsconfig.json             # Configuração do TypeScript
 ├── README.md                 # Documentação do projeto
 ├── .gitignore                # Arquivos ignorados pelo Git
+├── cli/                     # Código da interface de linha de comando
+│   └── index.ts             # Entrada da CLI
 └── src/
     ├── index.ts              # Entrada principal do sistema
-    ├── cli/
-    │   └── index.ts          # CLI interativa (terminal)
     ├── core/
     │   ├── fileManager.ts    # Funções de leitura e movimentação de arquivos
     │   ├── organizer.ts      # Funções de organização inteligente
@@ -41,3 +41,9 @@ voyin/
     │       └── Gui.tsx       # Componente principal da interface
     └── types/
         └── index.ts          # Tipagens compartilhadas
+
+Para iniciar a interface de linha de comando utilize:
+
+```bash
+npm run cli
+```

--- a/cli/actions/handleConverter.ts
+++ b/cli/actions/handleConverter.ts
@@ -1,5 +1,23 @@
+import inquirer from 'inquirer'
 import chalk from 'chalk'
+import { convertFile } from '../../src/core/fileManager/index.js'
 
 export async function handleConverter(): Promise<void> {
-  console.log(chalk.yellow('Conversor ainda não implementado.'))
+  const { input, output, type } = await inquirer.prompt([
+    { type: 'input', name: 'input', message: 'Arquivo de entrada:' },
+    { type: 'input', name: 'output', message: 'Arquivo de saída:' },
+    {
+      type: 'list',
+      name: 'type',
+      message: 'Tipo de conversão:',
+      choices: ['pdfToPng', 'pdfToWord', 'wordToPdf', 'excelToPdf', 'txtToPdf']
+    }
+  ])
+
+  try {
+    await convertFile({ input, output, type })
+    console.log(chalk.green('✅ Conversão concluída.'))
+  } catch (err) {
+    console.log(chalk.red(`Erro: ${(err as Error).message}`))
+  }
 }

--- a/cli/actions/handleDuplicator.ts
+++ b/cli/actions/handleDuplicator.ts
@@ -1,5 +1,60 @@
+import inquirer from 'inquirer'
 import chalk from 'chalk'
+import {
+  findDuplicateNames,
+  findDuplicateContents,
+  deleteDuplicates
+} from '../../src/core/duplicator/index.js'
 
 export async function handleDuplicator(): Promise<void> {
-  console.log(chalk.yellow('Detecção de duplicados ainda não implementada.'))
+  while (true) {
+    const { action } = await inquirer.prompt({
+      type: 'list',
+      name: 'action',
+      message: 'Opções de duplicados:',
+      choices: [
+        { name: 'Procurar nomes duplicados', value: 'names' },
+        { name: 'Procurar conteúdo duplicado', value: 'contents' },
+        { name: 'Voltar', value: 'back' }
+      ]
+    })
+
+    if (action === 'back') return
+
+    const { dir } = await inquirer.prompt({
+      type: 'input',
+      name: 'dir',
+      message: 'Diretório para analisar:'
+    })
+
+    try {
+      const duplicates =
+        action === 'names'
+          ? findDuplicateNames(dir)
+          : findDuplicateContents(dir)
+
+      if (Object.keys(duplicates).length === 0) {
+        console.log(chalk.green('Nenhum duplicado encontrado.'))
+        continue
+      }
+
+      console.log(chalk.yellow('Duplicados encontrados:'))
+      Object.values(duplicates).forEach(grp =>
+        console.log(' - ' + grp.join('\n   '))
+      )
+
+      const { remove } = await inquirer.prompt({
+        type: 'confirm',
+        name: 'remove',
+        message: 'Deletar cópias deixando apenas uma?' ,
+        default: false
+      })
+
+      if (remove) {
+        await deleteDuplicates(duplicates)
+      }
+    } catch (err) {
+      console.log(chalk.red(`Erro: ${(err as Error).message}`))
+    }
+  }
 }

--- a/cli/actions/handleExtras.ts
+++ b/cli/actions/handleExtras.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
 
 export async function handleExtras(): Promise<void> {
-  console.log(chalk.yellow('Funcionalidades extras ainda não implementadas.'))
+  console.log(chalk.yellow('Nenhuma funcionalidade extra disponível.'))
 }

--- a/cli/actions/handleFile.ts
+++ b/cli/actions/handleFile.ts
@@ -1,5 +1,133 @@
+import inquirer from 'inquirer'
 import chalk from 'chalk'
+import {
+  createFile,
+  readFile,
+  updateFile,
+  renameFile,
+  moveFile,
+  copyFile,
+  deleteFile,
+  convertFile
+} from '../../src/core/fileManager/index.js'
 
 export async function handleFile(): Promise<void> {
-  console.log(chalk.yellow('Funcionalidade de arquivos ainda não implementada.'))
+  while (true) {
+    const { action } = await inquirer.prompt({
+      type: 'list',
+      name: 'action',
+      message: 'Escolha uma operação de arquivo:',
+      choices: [
+        { name: 'Criar arquivo', value: 'create' },
+        { name: 'Ler arquivo', value: 'read' },
+        { name: 'Atualizar arquivo', value: 'update' },
+        { name: 'Renomear arquivo', value: 'rename' },
+        { name: 'Mover arquivo', value: 'move' },
+        { name: 'Copiar arquivo', value: 'copy' },
+        { name: 'Deletar arquivo', value: 'delete' },
+        { name: 'Converter arquivo', value: 'convert' },
+        { name: 'Voltar', value: 'back' }
+      ]
+    })
+
+    try {
+      switch (action) {
+        case 'create': {
+          const { path, content } = await inquirer.prompt([
+            { type: 'input', name: 'path', message: 'Caminho do novo arquivo:' },
+            {
+              type: 'input',
+              name: 'content',
+              message: 'Conteúdo inicial (opcional):',
+              default: ''
+            }
+          ])
+          await createFile(path, content)
+          console.log(chalk.green('✅ Arquivo criado.'))
+          break
+        }
+        case 'read': {
+          const { path } = await inquirer.prompt({
+            type: 'input',
+            name: 'path',
+            message: 'Caminho do arquivo:'
+          })
+          const content = await readFile(path)
+          console.log(chalk.cyan('\n' + content + '\n'))
+          break
+        }
+        case 'update': {
+          const { path, newContent } = await inquirer.prompt([
+            { type: 'input', name: 'path', message: 'Arquivo a atualizar:' },
+            { type: 'input', name: 'newContent', message: 'Novo conteúdo:' }
+          ])
+          await updateFile(path, newContent)
+          console.log(chalk.green('✅ Arquivo atualizado.'))
+          break
+        }
+        case 'rename': {
+          const { path, name } = await inquirer.prompt([
+            { type: 'input', name: 'path', message: 'Arquivo a renomear:' },
+            { type: 'input', name: 'name', message: 'Novo nome:' }
+          ])
+          await renameFile(path, name)
+          console.log(chalk.green('✅ Arquivo renomeado.'))
+          break
+        }
+        case 'move': {
+          const { from, to } = await inquirer.prompt([
+            { type: 'input', name: 'from', message: 'Arquivo de origem:' },
+            { type: 'input', name: 'to', message: 'Pasta destino:' }
+          ])
+          await moveFile(from, to)
+          console.log(chalk.green('✅ Arquivo movido.'))
+          break
+        }
+        case 'copy': {
+          const { from, to } = await inquirer.prompt([
+            { type: 'input', name: 'from', message: 'Arquivo de origem:' },
+            { type: 'input', name: 'to', message: 'Pasta destino:' }
+          ])
+          await copyFile(from, to)
+          console.log(chalk.green('✅ Arquivo copiado.'))
+          break
+        }
+        case 'delete': {
+          const { path } = await inquirer.prompt({
+            type: 'input',
+            name: 'path',
+            message: 'Arquivo a deletar:'
+          })
+          await deleteFile(path)
+          console.log(chalk.green('✅ Arquivo deletado.'))
+          break
+        }
+        case 'convert': {
+          const { input, output, type } = await inquirer.prompt([
+            { type: 'input', name: 'input', message: 'Arquivo de entrada:' },
+            { type: 'input', name: 'output', message: 'Arquivo de saída:' },
+            {
+              type: 'list',
+              name: 'type',
+              message: 'Tipo de conversão:',
+              choices: [
+                'pdfToPng',
+                'pdfToWord',
+                'wordToPdf',
+                'excelToPdf',
+                'txtToPdf'
+              ]
+            }
+          ])
+          await convertFile({ input, output, type })
+          console.log(chalk.green('✅ Conversão concluída.'))
+          break
+        }
+        case 'back':
+          return
+      }
+    } catch (err) {
+      console.log(chalk.red(`Erro: ${(err as Error).message}`))
+    }
+  }
 }

--- a/cli/actions/handleFolder.ts
+++ b/cli/actions/handleFolder.ts
@@ -1,5 +1,95 @@
+import inquirer from 'inquirer'
 import chalk from 'chalk'
+import {
+  createFolder,
+  listFolder,
+  renameFolder,
+  moveFolder,
+  copyFolder,
+  deleteFolder
+} from '../../src/core/folderManager/index.js'
 
 export async function handleFolder(): Promise<void> {
-  console.log(chalk.yellow('Funcionalidade de pastas ainda não implementada.'))
+  while (true) {
+    const { action } = await inquirer.prompt({
+      type: 'list',
+      name: 'action',
+      message: 'Operações de pasta:',
+      choices: [
+        { name: 'Criar pasta', value: 'create' },
+        { name: 'Listar pasta', value: 'list' },
+        { name: 'Renomear pasta', value: 'rename' },
+        { name: 'Mover pasta', value: 'move' },
+        { name: 'Copiar pasta', value: 'copy' },
+        { name: 'Deletar pasta', value: 'delete' },
+        { name: 'Voltar', value: 'back' }
+      ]
+    })
+
+    try {
+      switch (action) {
+        case 'create': {
+          const { path } = await inquirer.prompt({
+            type: 'input',
+            name: 'path',
+            message: 'Nova pasta:'
+          })
+          await createFolder(path)
+          console.log(chalk.green('✅ Pasta criada.'))
+          break
+        }
+        case 'list': {
+          const { path } = await inquirer.prompt({
+            type: 'input',
+            name: 'path',
+            message: 'Pasta a listar:'
+          })
+          const items = await listFolder(path)
+          console.log(items.join('\n') || '(vazio)')
+          break
+        }
+        case 'rename': {
+          const { path, name } = await inquirer.prompt([
+            { type: 'input', name: 'path', message: 'Pasta a renomear:' },
+            { type: 'input', name: 'name', message: 'Novo nome:' }
+          ])
+          await renameFolder(path, name)
+          console.log(chalk.green('✅ Pasta renomeada.'))
+          break
+        }
+        case 'move': {
+          const { from, to } = await inquirer.prompt([
+            { type: 'input', name: 'from', message: 'Pasta de origem:' },
+            { type: 'input', name: 'to', message: 'Diretório destino:' }
+          ])
+          await moveFolder(from, to)
+          console.log(chalk.green('✅ Pasta movida.'))
+          break
+        }
+        case 'copy': {
+          const { from, to } = await inquirer.prompt([
+            { type: 'input', name: 'from', message: 'Pasta de origem:' },
+            { type: 'input', name: 'to', message: 'Diretório destino:' }
+          ])
+          await copyFolder(from, to)
+          console.log(chalk.green('✅ Pasta copiada.'))
+          break
+        }
+        case 'delete': {
+          const { path } = await inquirer.prompt({
+            type: 'input',
+            name: 'path',
+            message: 'Pasta a deletar:'
+          })
+          await deleteFolder(path)
+          console.log(chalk.green('✅ Pasta deletada.'))
+          break
+        }
+        case 'back':
+          return
+      }
+    } catch (err) {
+      console.log(chalk.red(`Erro: ${(err as Error).message}`))
+    }
+  }
 }

--- a/cli/actions/handleOrganizer.ts
+++ b/cli/actions/handleOrganizer.ts
@@ -1,5 +1,53 @@
+import inquirer from 'inquirer'
 import chalk from 'chalk'
+import {
+  organizeByExtension,
+  analyzeFolderPattern
+} from '../../src/core/organizer/index.js'
 
 export async function handleOrganizer(): Promise<void> {
-  console.log(chalk.yellow('Organizador ainda não implementado.'))
+  while (true) {
+    const { action } = await inquirer.prompt({
+      type: 'list',
+      name: 'action',
+      message: 'Organização de arquivos:',
+      choices: [
+        { name: 'Organizar por extensão', value: 'byExt' },
+        { name: 'Analisar padrão de pasta', value: 'analyze' },
+        { name: 'Voltar', value: 'back' }
+      ]
+    })
+
+    try {
+      switch (action) {
+        case 'byExt': {
+          const { dir } = await inquirer.prompt({
+            type: 'input',
+            name: 'dir',
+            message: 'Pasta para organizar:'
+          })
+          await organizeByExtension(dir)
+          break
+        }
+        case 'analyze': {
+          const { dir } = await inquirer.prompt({
+            type: 'input',
+            name: 'dir',
+            message: 'Pasta para analisar:'
+          })
+          const result = analyzeFolderPattern(dir)
+          console.log(
+            chalk.cyan(
+              `Padrão: ${result.padrao}\nSugestão: ${result.sugestao}\nConfiança: ${result.confianca}%`
+            )
+          )
+          break
+        }
+        case 'back':
+          return
+      }
+    } catch (err) {
+      console.log(chalk.red(`Erro: ${(err as Error).message}`))
+    }
+  }
 }

--- a/cli/actions/handleReport.ts
+++ b/cli/actions/handleReport.ts
@@ -1,5 +1,17 @@
+import inquirer from 'inquirer'
 import chalk from 'chalk'
+import { generateFullReport } from '../../src/core/reporter/index.js'
 
 export async function handleReport(): Promise<void> {
-  console.log(chalk.yellow('Geração de relatórios ainda não implementada.'))
+  const { dir } = await inquirer.prompt({
+    type: 'input',
+    name: 'dir',
+    message: 'Diretório para gerar relatório:'
+  })
+
+  try {
+    await generateFullReport(dir)
+  } catch (err) {
+    console.log(chalk.red(`Erro: ${(err as Error).message}`))
+  }
 }

--- a/cli/menus/menuData.ts
+++ b/cli/menus/menuData.ts
@@ -42,7 +42,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Arquivos',
     message: 'Gerenciar arquivos:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleFile },
+      { name: 'Abrir menu de arquivos', value: 'run', action: handleFile },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   },
@@ -50,7 +50,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Pastas',
     message: 'Gerenciar pastas:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleFolder },
+      { name: 'Abrir menu de pastas', value: 'run', action: handleFolder },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   },
@@ -58,7 +58,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Organizador',
     message: 'Organizar arquivos:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleOrganizer },
+      { name: 'Abrir menu do organizador', value: 'run', action: handleOrganizer },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   },
@@ -66,7 +66,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Relatórios',
     message: 'Gerar relatórios:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleReport },
+      { name: 'Gerar relatório', value: 'run', action: handleReport },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   },
@@ -74,7 +74,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Duplicados',
     message: 'Detectar duplicados:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleDuplicator },
+      { name: 'Abrir menu de duplicados', value: 'run', action: handleDuplicator },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   },
@@ -82,7 +82,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Conversores',
     message: 'Converter arquivos:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleConverter },
+      { name: 'Converter arquivo', value: 'run', action: handleConverter },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   },
@@ -90,7 +90,7 @@ export const menus: Record<string, MenuDefinition> = {
     label: 'Extras',
     message: 'Opções extras:',
     options: [
-      { name: 'Em breve...', value: 'placeholder', action: handleExtras },
+      { name: 'Executar extras', value: 'run', action: handleExtras },
       { name: '🔙 Voltar', value: 'back', next: '..' }
     ]
   }


### PR DESCRIPTION
## Summary
- expand CLI actions to use core features
- update menu data to call new actions
- document CLI location and execution in README

## Testing
- `npm run build` *(fails: Cannot find module 'fs-extra' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68574824c7e48330b4deeb14e5cc5da6